### PR TITLE
Fixed: data.length undefined error on history and browse pages

### DIFF
--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -70,7 +70,7 @@
           offset: this.offset,
           append: true
         })
-          .then(() => {
+          .then(data => {
             this.loadingMore = false;
             if (this.mediaList.length % this.limit != 0 || data.length == 0) {
               this.canLoadMore = false;

--- a/src/store/media.js
+++ b/src/store/media.js
@@ -85,6 +85,8 @@ export default {
           } else {
             commit('setSeriesList', data);
           }
+
+          return data
         })
         .catch(({code}) => {
           if (code == 'bad_session') {
@@ -215,6 +217,8 @@ export default {
           } else {
             commit('setMediaList', mediaList);
           }
+
+          return data
         })
         .catch(({code}) => {
           if (code == 'bad_session') {


### PR DESCRIPTION
When you click Load More you get the following error:

![image](https://user-images.githubusercontent.com/5081482/53249557-428a1380-36b0-11e9-8f41-224eb9251f0e.png)