### PR TITLE
Fixed: Hide load more button on History page if empty

### DIFF
--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -70,7 +70,7 @@
           offset: this.offset,
           append: true
         })
-          .then(() => {
+          .then(data => {
             this.loadingMore = false;
             if (this.mediaList.length % this.limit != 0 || data.length == 0) {
               this.canLoadMore = false;

--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -4,6 +4,10 @@
       <dropdown-selector class="col-lg-3 col-md-4 col-sm-6 mb-2" :label="$t('media.media')" :options="mediaOptions" @selectionUpdate="selection => {mediaType = selection; updateMediaList()}" />
     </div>
 
+    <div class="alert alert-info" v-if="!mediaList.length">
+      Your history is currently empty, when you watch an episode it will show up here.
+    </div>
+
     <div class="mb-4" v-if="!loading">
       <div class="row">
         <div class="col-lg-3 col-md-4 col-sm-6 offset-sm-0 col-8 offset-2 mb-4" v-for="media in mediaList" :key="media.media_id">
@@ -55,8 +59,12 @@
           limit: this.limit,
           offset: this.offset
         })
-          .then(() => {
+          .then(data => {
             this.loading = false;
+
+            if (data.length == 0) {
+              this.canLoadMore = false;
+            }
           });
       },
 

--- a/src/store/media.js
+++ b/src/store/media.js
@@ -85,6 +85,8 @@ export default {
           } else {
             commit('setSeriesList', data);
           }
+
+          return data
         })
         .catch(({code}) => {
           if (code == 'bad_session') {
@@ -215,6 +217,8 @@ export default {
           } else {
             commit('setMediaList', mediaList);
           }
+
+          return data
         })
         .catch(({code}) => {
           if (code == 'bad_session') {


### PR DESCRIPTION
The alert text and load more button still need to be translated