### PR TITLE
Context menu media card fixes

### DIFF
--- a/src/event-bus.js
+++ b/src/event-bus.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+
+export default new Vue()

--- a/src/modules/cards/MediaCard.vue
+++ b/src/modules/cards/MediaCard.vue
@@ -43,6 +43,7 @@ import ProgressBar from 'modules/shared/ProgressBar'
 import Card from './Card'
 import MediaCardContext from './MediaCardContext'
 import Loading from 'modules/shared/Loading'
+import EventBus from 'event-bus'
 
 export default {
   name: 'media-card',
@@ -65,8 +66,15 @@ export default {
     MediaCardContext,
     Loading
   },
+  created () {
+    EventBus.$on('closeContextMenus', () => {
+      this.showContextMenu = false
+    })
+  },
   methods: {
     contextMenu (event) {
+      EventBus.$emit('closeContextMenus')
+
       this.showContextMenu = true
       this.contextMenuPosition.x = event.clientX - this.$refs.card.$el.getBoundingClientRect().left
       this.contextMenuPosition.y = event.clientY - this.$refs.card.$el.getBoundingClientRect().top

--- a/src/modules/cards/MediaCardContext.vue
+++ b/src/modules/cards/MediaCardContext.vue
@@ -36,3 +36,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .list-group-item {
+    z-index: 1;
+  }
+</style>

--- a/src/modules/cards/SeriesCard.vue
+++ b/src/modules/cards/SeriesCard.vue
@@ -32,6 +32,7 @@ import Ribbon from './Ribbon'
 import Popper from 'popper.js'
 import Loading from 'modules/shared/Loading'
 import SeriesCardContext from './SeriesCardContext'
+import EventBus from 'event-bus'
 
 export default {
   name: 'series-card',
@@ -47,6 +48,11 @@ export default {
   mounted () {
     this.popper = new Popper(this.$refs.card.$el, this.$refs.popper.$el, { placement: 'right-start' })
   },
+  created () {
+    EventBus.$on('closeContextMenus', () => {
+      this.showContextMenu = false
+    })
+  },
   methods: {
     setPopperVisible (visible) {
       this.showPopper = visible
@@ -54,6 +60,8 @@ export default {
       this.popper.scheduleUpdate()
     },
     contextMenu (event) {
+      EventBus.$emit('closeContextMenus')
+
       this.showContextMenu = true
       this.contextMenuPosition.x = event.clientX - this.$refs.card.$el.getBoundingClientRect().left
       this.contextMenuPosition.y = event.clientY - this.$refs.card.$el.getBoundingClientRect().top

--- a/src/modules/cards/SeriesCardContext.vue
+++ b/src/modules/cards/SeriesCardContext.vue
@@ -35,3 +35,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .list-group-item {
+    z-index: 1;
+  }
+</style>


### PR DESCRIPTION
- Fixed: Close context menus on other media cards when a new one is opened
- Fixed: Media card context menus being hidden under other media cards